### PR TITLE
Add Agent Registry - on-chain identity standard for AI agents (ERC #1757)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Application platforms:
 ## Standards
 
 * [Agent Protocol](https://agentprotocol.ai/): standard interface for AI agents
+* [Agent Registry](https://github.com/Brooks1003/base-agent-registry): on-chain identity, capability, reputation, staking, and distributed deployment standard for autonomous AI agents (ERC #1757)
 
 
 ## Related lists


### PR DESCRIPTION
## Summary

Add [Agent Registry](https://github.com/Brooks1003/base-agent-registry) to the **Standards** section.

Agent Registry is an open standard for:
- **On-chain identity** for autonomous AI agents (Agent #1 already registered)
- **Capability declaration** — including distributed protocols (Bittensor, Fluence, IPFS)
- **Reputation and staking** — economic security via slashable stakes
- **Audit framework** — independent code audits
- **ERC #1757** — submitted to Ethereum as a formal standard

Fits directly under "Standards" alongside Agent Protocol.